### PR TITLE
fstab: re-add F2FS mounts

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -9,8 +9,11 @@
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot            emmc    defaults                                                                    recoveryonly
 /dev/block/platform/msm_sdcc.1/by-name/recovery     /recovery        emmc    defaults                                                                    recoveryonly
 /dev/block/platform/msm_sdcc.1/by-name/misc         /misc            emmc    defaults                                                                    recoveryonly
+/dev/block/platform/msm_sdcc.1/by-name/system       /system          f2fs    ro,noatime,nodev,discard,nodiratime,inline_xattr		         wait
 /dev/block/platform/msm_sdcc.1/by-name/system       /system          ext4    ro,seclabel,noatime,data=ordered                                            wait
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data            f2fs    rw,discard,nosuid,nodev,noatime,nodiratime,inline_xattr	                 wait,check,encryptable=/dev/block/platform/msm_sdcc.1/by-name/extra
 /dev/block/platform/msm_sdcc.1/by-name/userdata     /data            ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,journal_async_commit,errors=panic wait,check,encryptable=/dev/block/platform/msm_sdcc.1/by-name/extra
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache           f2fs    rw,discard,nosuid,nodev,noatime,nodiratime,inline_xattr	                 wait,check
 /dev/block/platform/msm_sdcc.1/by-name/cache        /cache           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,journal_async_commit,errors=panic wait,check
 /dev/block/platform/msm_sdcc.1/by-name/radio        /firmware/radio  vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0                    wait
 /dev/block/platform/msm_sdcc.1/by-name/adsp         /firmware/adsp   vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0                    wait


### PR DESCRIPTION
Re-add cache and userdata mount command for F2FS, also include system
mount command.

This has been tested and works on M8, shouldn't cause issues if F2FS is not enabled in kernel.
